### PR TITLE
compatibility with RabbitMQ 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "amqplib": "^0.10.3",
+    "amqplib": "^0.10.8",
     "lodash.clonedeep": "^4.5.0",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
RabbitMQ compatibility due to amqplib in rabbitmq 4.1 [needing it](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0).
Under 
Breaking Changes and Compatibility Notes:
Node.js amqplib Must Be Upgraded


https://github.com/rabbitmq/rabbitmq-server/discussions/13849
